### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "langchain-openai>=0.0.2",
     "litellm>=1.59.8",
     "openai>=1.0.0",
-    "pyautogen>=0.7.3",
+    "ag2>=0.7.3",
     "vertexai>=1.43.0",
 
     # Core Dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ langchain-ollama>=0.2.3
 langchain-openai>=0.0.2
 litellm>=1.59.8
 openai>=1.0.0
-pyautogen>=0.7.3
+ag2>=0.7.3
 vertexai>=1.43.0
 
 # Core Dependencies

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "langchain-openai>=0.0.2",
         "litellm>=1.59.8",
         "openai>=1.0.0",
-        "pyautogen>=0.7.3",
+        "ag2>=0.7.3",
         "pydantic>=2.10.6",
         "pyjwt>=2.10.1",
         "python-dotenv>=1.0.1",


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
